### PR TITLE
Set clap ~> 1.0.0 as dependency

### DIFF
--- a/dep.gemspec
+++ b/dep.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.files             = ["README.1", "bin/dep", "lib/dep.rb", "test/dep.rb"]
 
   s.executables.push("dep")
-  s.add_dependency("clap", "~> 0.0.2")
+  s.add_dependency("clap", "~> 1.0.0")
 end


### PR DESCRIPTION
`dep` was using clap 0.0.2 as runtime dependency. Updated gemspec to require latest clap version.
