### PR TITLE
remove __FILE__==$0 condition to work with rubygems bin wrapper

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -146,42 +146,40 @@ private
   end
 end
 
-if __FILE__ == $0
 
-  Dep::CLI.file = File.join(Dir.pwd, ".gems")
-  Dep::CLI.prerelease = false
+Dep::CLI.file = File.join(Dir.pwd, ".gems")
+Dep::CLI.prerelease = false
 
-  on("-f") do |file|
-    Dep::CLI.file = file
-  end
-
-  on("--pre") do
-    Dep::CLI.prerelease = true
-  end
-
-  on("--help") do
-    IO.popen("less", "w") { |f| f.write(DATA.read) }
-    exit
-  end
-
-  Dep::CLI.list = Dep::List.new(Dep::CLI.file)
-
-  FileUtils.touch(Dep::CLI.list.path) unless File.exist?(Dep::CLI.list.path)
-
-  case ARGV[0]
-  when "add"
-    Dep::CLI.add(ARGV[1])
-  when "rm"
-    Dep::CLI.rm(ARGV[1])
-  when "install", "i"
-    Dep::CLI.install
-  when nil
-    Dep::CLI.check
-  else
-    Dep::CLI.abort
-  end
-
+on("-f") do |file|
+  Dep::CLI.file = file
 end
+
+on("--pre") do
+  Dep::CLI.prerelease = true
+end
+
+on("--help") do
+  IO.popen("less", "w") { |f| f.write(DATA.read) }
+  exit
+end
+
+Dep::CLI.list = Dep::List.new(Dep::CLI.file)
+
+FileUtils.touch(Dep::CLI.list.path) unless File.exist?(Dep::CLI.list.path)
+
+case ARGV[0]
+when "add"
+  Dep::CLI.add(ARGV[1])
+when "rm"
+  Dep::CLI.rm(ARGV[1])
+when "install", "i"
+  Dep::CLI.install
+when nil
+  Dep::CLI.check
+else
+  Dep::CLI.abort
+end
+
 
 __END__
 

--- a/bin/dep
+++ b/bin/dep
@@ -174,7 +174,7 @@ when "rm"
   Dep::CLI.rm(ARGV[1])
 when "install", "i"
   Dep::CLI.install
-when nil
+when nil, "check"
   Dep::CLI.check
 else
   Dep::CLI.abort
@@ -189,13 +189,13 @@ NAME
       dep -- Basic dependency tracking
 
 SYNOPSIS
-      dep
+      dep [check]
       dep add libname [--pre]
       dep rm libname
       dep install
 
 DESCRIPTION
-      dep
+      dep [check]
           Checks that all dependencies are met.
 
       dep add [gemname]


### PR DESCRIPTION
Not sure if there is a reason for that condition anymore, but anyway it fixes #7 so dep works from `gem install dep` . 

Also second commit allows `dep check` as synonym for `dep`, as the README says.
