### PR TITLE
Removes redundant struct

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -36,7 +36,7 @@ module Dep
     end
   end
 
-  class Lib < Struct.new(:name, :version)
+  Lib = Struct.new(:name, :version) do
     def self.[](line)
       if line.strip =~ /^(\S+) -v (\S+)$/
         return new($1, $2)


### PR DESCRIPTION
This is a totally stupid PR but I'll send it because I was going to add going to add a feature to `CLI.add` to allow multiple additions but then I regret it :P 

Using `class Something < Struct.new(:a)` generates a useless instance of which the class inherits. It can be called `Something = Struct.new(:a)`

``` ruby
class A < Struct.new(:a)
end

B = Struct.new(:b)

A.ancestors
# => [A, #<Class:0x007fbee3027908>, Struct, Enumerable, Object, Kernel, BasicObject]

B.ancestors
# => [B, Struct, Enumerable, Object, Kernel, BasicObject]
```

Again, this is probably stupid but I enjoy reading your code.
