### PR TITLE
Adapt to new .gems file format

### DIFF
--- a/README
+++ b/README
@@ -79,7 +79,7 @@ HISTORY
       The manual workflow for that would be:
 
       gem search -r "^ohm$" [--pre] # check and remember the version number
-      echo "ohm -v X.x.x" >> .gems
+      echo "ohm:X.x.x" >> .gems
 
       If you try doing that repeatedly, it will quickly become cumbersome.
 

--- a/bin/dep
+++ b/bin/dep
@@ -42,7 +42,7 @@ module Dep
 
   class Lib < Struct.new(:name, :version)
     def self.[](line)
-      if line.strip =~ /^(\S+) -v (\S+)$/
+      if line.strip =~ /^(\S+):(\S+)$/
         return new($1, $2)
       else
         abort("Invalid requirement found: #{line}")


### PR DESCRIPTION
Guys, this is bad, dep 1.0.7 is broken.

![dep](https://cloud.githubusercontent.com/assets/132684/3342250/8b5ba2b2-f890-11e3-8de2-58e3f1d1ccf8.gif)

This PR solves it by adapting to invalid argument check to the new format.
