### PR TITLE
Report failures setting an exit status

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -126,6 +126,10 @@ module Dep
     def run(cmd)
       puts "  #{cmd}"
       `#{cmd}`
+
+      if $?.exitstatus != 0
+        exit($?.exitstatus)
+      end
     end
   end
 end


### PR DESCRIPTION
Propagate exit status from `gem install` when some gem or gems can't be installed.
This allows scripts to be able to respond accordingly.
