### PR TITLE
Exit with failure code when `gem install` command fails.

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -126,6 +126,8 @@ module Dep
     def run(cmd)
       puts "  #{cmd}"
       `#{cmd}`
+
+      exit false if $?.to_i != 0
     end
   end
 end


### PR DESCRIPTION
This PR makes `dep install` exit with a failure code when the internal `gem install` command fails.

This makes it possible to integrate `dep install` into scripts that have to know whether the installation succeeded or failed (so they can abort the rest of the script, or take some other failure-handling action).
